### PR TITLE
Recode deck parsing to eliminate sb 'hack'

### DIFF
--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -73,7 +73,7 @@ class Hooks {
 				// This line is a section title
 				$thisSection = trim( preg_replace( '/[^A-Za-z- ]/', '', $line[0] ) );
 				$isSideboard = in_array( strtolower( $thisSection ), [ 'sideboard', 'sb' ] );
-				if ( $isSideboard )	{
+				if ( $isSideboard ) {
 					$current = &$sideboard;
 				} else {
 					$current = &$cards;
@@ -94,7 +94,7 @@ class Hooks {
 	/**
 	 * Build the HTML for a <deck> tag
 	 * @param string $decktitle The title for the deck
-	 * @param array $cards The card list (see self::parseDeckCards)
+	 * @param array &$cards The card list (see self::parseDeckCards)
 	 * @return string
 	 */
 	private static function buildDeckHtml( $decktitle, &$cards ) {


### PR DESCRIPTION
Re-coded the parsing of decks to eliminate the code to deal with moving the sideboard cards to the end, which was commented as a 'hack'. Now uses a separate array to accumulate sideboard cards and appends this to the end of the cards array after parsing.

Also moved the building of the deck HTML to it's own routine. The HTML building code is unchanged.