### PR TITLE
Localization support for card tooltips

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -35,6 +35,9 @@
 			"targets": [
 				"desktop",
 				"mobile"
+			],
+			"messages": [
+				"scryfalllinks-unrecognized-card"	
 			]
 		},
 		"ext.scryfallLinks.deckExport": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,9 +1,10 @@
 {
 	"@metadata": {
 		"authors": [
-			"Nils Enevoldsen"
+			"Nils Enevoldsen",
+			"Aspallar"
 		]
 	},
 	"scryfalllinks-desc": "Creates Scryfall links from Magic: The Gathering card names.",
-	"scryfalllinks-i18n-welcome": "Welcome to the localization file of the ScryfallLinks extension."
+	"scryfalllinks-unrecognized-card": "Unrecognized card"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -1,13 +1,10 @@
 {
 	"@metadata": {
 		"authors": [
-			"Shirayuki",
-			"Umherirrender",
-			"Amire80",
-			"Fhocutt",
-			"Liuxinyu970226"
+			"Nils Enevoldsen",
+			"Aspallar"
 		]
 	},
 	"scryfalllinks-desc": "{{desc|name=ScryfallLinks|url=https://github.com/NilsEnevoldsen/ScryfallLinks}}",
-	"scryfalllinks-i18n-welcome": "Used to greet the user when reading the i18n/??.json file."
+	"scryfalllinks-unrecognized-card": "Contents of card tooltip if card cannot be found on Scryfall"
 }

--- a/resources/ext.scryfallLinks.tooltip.js
+++ b/resources/ext.scryfallLinks.tooltip.js
@@ -88,7 +88,7 @@
 		}
 	}
 
-	$( function () {
+	function initTippy() {
 		/* global tippy */
 		tippy( '.ext-scryfall-cardname', {
 			arrow: false,
@@ -138,9 +138,8 @@
 						await correctPromise;
 						tip.reference.dataset.cached = true;
 					} catch ( e ) {
-						// TODO: This should be localized
 						if ( e.message === '404' ) {
-							tip.setContent( 'Unrecognized card' );
+							tip.setContent( mw.message( 'scryfalllinks-unrecognized-card' ).escaped() );
 							// If we get a 404, we'll also short-circuit all future attempts
 							tip.reference.dataset.unrecognized = true;
 						} else {
@@ -160,5 +159,11 @@
 				tip.setContent( '' );
 			}
 		} );
-	}() );
+	}
+
+	$( function () {
+		mw.loader.using( 'mediawiki.api' ).then( () => {
+			return new mw.Api().loadMessagesIfMissing( [ 'scryfalllinks-unrecognized-card' ] );
+		} ).then( initTippy );
+	} );
 }


### PR DESCRIPTION
Did the todo in ext.scryfallLinks.tooltip.js

```javascript
// TODO: This should be localized
if ( e.message === '404' ) {
        tip.setContent( 'Unrecognized card' );
```

