### PR TITLE
Use wikipage.content hook + minor parseXMLDeck mods

### DIFF
--- a/resources/ext.scryfallLinks.deckExport.js
+++ b/resources/ext.scryfallLinks.deckExport.js
@@ -72,17 +72,19 @@
 		};
 
 	// parseXMLDeck() accepts a <deck> in XML and returns it in JSON
-	function parseXMLDeck( xmlDeck ) {
+	function parseXMLDeck( $xmlDeck ) {
 		const deck = Object.create( Deck );
-		deck.title = $( xmlDeck ).find( '.ext-scryfall-decktitle' ).text();
-		deck.sectionlist = $( xmlDeck ).find( '.ext-scryfall-decksection' ).toArray().map( ( section ) => {
-			const deckSection = Object.create( DeckSection );
-			deckSection.title = $( section ).find( '.ext-scryfall-decksectiontitle' ).text();
+		deck.title = $xmlDeck.find( '.ext-scryfall-decktitle' ).text();
+		deck.sectionlist = $xmlDeck.find( '.ext-scryfall-decksection' ).toArray().map( ( section ) => {
+			const deckSection = Object.create( DeckSection ),
+				$section = $( section );
+			deckSection.title = $section.find( '.ext-scryfall-decksectiontitle' ).text();
 			deckSection.isSideboard = section.classList.contains( 'ext-scryfall-decksideboard' );
-			deckSection.cardlist = $( section ).find( '.ext-scryfall-deckentry' ).toArray().map( ( entry ) => {
-				const deckEntry = Object.create( DeckEntry );
-				deckEntry.count = +( $( entry ).find( '.ext-scryfall-deckcardcount' ).text() );
-				deckEntry.name = $( entry ).find( '.ext-scryfall-cardname' ).text();
+			deckSection.cardlist = $section.find( '.ext-scryfall-deckentry' ).toArray().map( ( entry ) => {
+				const deckEntry = Object.create( DeckEntry ),
+					$entry = $( entry );
+				deckEntry.count = +( $entry.find( '.ext-scryfall-deckcardcount' ).text() );
+				deckEntry.name = $entry.find( '.ext-scryfall-cardname' ).text();
 				return deckEntry;
 			} );
 			return deckSection;
@@ -116,8 +118,11 @@
 		console.log( contenttype + '\n' + filename + '\n' + data ); // eslint-disable-line no-console
 	}
 
-	$( function () {
-		$( '.ext-scryfall-deckexport-text' ).on( 'click', ( event ) => {
+	// Initialize the download dropdown menu(s)
+	function initDownloadUi( $content ) {
+		const $decks = $content.find( '.ext-scryfall-deckexport' ).not( '.loaded' );
+
+		$decks.find( 'button.ext-scryfall-deckexport-text' ).on( 'click', ( event ) => {
 			const deck = getDeck( event );
 			download(
 				deck.title + '.txt',
@@ -126,7 +131,7 @@
 			);
 		} );
 
-		$( '.ext-scryfall-deckexport-mtgo' ).on( 'click', ( event ) => {
+		$decks.find( '.ext-scryfall-deckexport-mtgo' ).on( 'click', ( event ) => {
 			const deck = getDeck( event );
 			download(
 				deck.title + '.txt',
@@ -135,7 +140,7 @@
 			);
 		} );
 
-		$( '.ext-scryfall-deckexport-apprentice' ).on( 'click', ( event ) => {
+		$decks.find( '.ext-scryfall-deckexport-apprentice' ).on( 'click', ( event ) => {
 			const deck = getDeck( event );
 			download(
 				deck.title + '.dec',
@@ -144,7 +149,7 @@
 			);
 		} );
 
-		$( '.ext-scryfall-deckexport-octgn' ).on( 'click', ( event ) => {
+		$decks.find( '.ext-scryfall-deckexport-octgn' ).on( 'click', ( event ) => {
 			const deck = getDeck( event );
 			download(
 				deck.title + '.o8d',
@@ -153,10 +158,17 @@
 			);
 		} );
 
-		$( '.ext-scryfall-deckexport-decklist' ).on( 'click', ( event ) => {
+		$decks.find( '.ext-scryfall-deckexport-decklist' ).on( 'click', ( event ) => {
 			const deck = getDeck( event ),
 				uri = new URL( deck.print( 'decklist.org' ) );
 			window.open( uri, '_blank' );
 		} );
-	} );
+
+		// 'wikipage.content' may fire multiple times for a given content so mark
+		// the download UI we just initialized as loaded so we don't repeat ourselves.
+		$decks.addClass( 'loaded' );
+	}
+
+	mw.hook( 'wikipage.content' ).add( initDownloadUi );
+
 }() );


### PR DESCRIPTION
This changes deck export to use the 'wikipage.content' hook to initialize the download menu rather than document.ready. This gets rid of the 5 eslint "Global selectors are not allowed" errors and makes the deck download compatible with dynamic content, i.e content added to the page after the document.ready fires.

(For instance there are extensions that change the preview during an edit to display in a popup rather than in-page, so no document,ready, using the hook will cause the menu to be initialized in such previews). A similar change should probably be made to the tooltip js.

Plus made some minor changes to the parseXMLDeck function, it was already being passed a jquery object so no need to $(xmlDeck), plus I cached jquery objects that were used more than once.

Regards
Asp