### PR TITLE
Fix Error from line 81 of /extensions/ScryfallLinks/src/Hooks.php: Call to undefined function MediaWiki\Extension\ScryfallLinks\is_set()

### DIFF
--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -78,7 +78,7 @@ class Hooks {
 				} else {
 					$current = &$cards;
 				}
-			} else if ( is_set( $line[0] ) && is_set( $line[1] ) ) {
+			} else if ( isset( $line[0] ) && isset( $line[1] ) ) {
 				// This line is a card name with a quantity
 				$current[] = [
 					'quantity' => $line[0],


### PR DESCRIPTION
Fixes

```
Error from line 81 of /extensions/ScryfallLinks/src/Hooks.php: Call to undefined function MediaWiki\Extension\ScryfallLinks\is_set()
```